### PR TITLE
Add support for SSR and remove syntax that doesn't compile

### DIFF
--- a/src/actions/AccountActions.js
+++ b/src/actions/AccountActions.js
@@ -32,7 +32,7 @@ export function makeAccount(props = {
  * returns { request, source }
  */
 export function createAccount(
-  account: Account,
+  account,
   onSuccess,
   onError,
   onCancel,

--- a/src/client/RevOpsAPIClient.js
+++ b/src/client/RevOpsAPIClient.js
@@ -1,15 +1,14 @@
 import axios from 'axios'
 
-import config from './VaultConfig'
+import getConfig from './VaultConfig'
 
 export class RevOpsAPIClient {
-  url = config.revopsBaseUrl
-
   constructor(url = false) {
+    url = getConfig().revopsBaseUrl
     if(url && url.length > 0) {
       this.url = url
     }
-    
+
     this.request = axios.create({
       baseURL: this.url
     })

--- a/src/client/VaultConfig.js
+++ b/src/client/VaultConfig.js
@@ -1,4 +1,4 @@
-const production = {
+const getProduction = () => ({
   name: 'production',
   vaultCollectUrl: 'https://js.verygoodvault.com/vgs-collect/1/ACvYkoDARh7Ajf3DhktqckgY.js',
   revopsBaseUrl: 'https://vault.revops.io',
@@ -8,9 +8,9 @@ const production = {
   vaultId: 'tnt2w1xznia',
   baseUrl: `https://${document.location.host}`,
   serviceName: 'revops-js-production',
-}
+})
 
-const staging = {
+const getStaging = () => ({
   name: 'staging',
   vaultCollectUrl: 'https://js.verygoodvault.com/vgs-collect/1/ACvYkoDARh7Ajf3DhktqckgY.js',
   revopsBaseUrl: 'https://vault.revops.io',
@@ -20,9 +20,9 @@ const staging = {
   vaultId: 'tnttz8hit8p',
   baseUrl: `https://${document.location.host}`,
   serviceName: 'revops-js-staging',
-}
+})
 
-const local = {
+const getLocal = () => ({
   name: "local",
   vaultCollectUrl: 'https://js.verygoodvault.com/vgs-collect/1/ACkcn4HYv7o2XoRa7idWwVEX.js',
   revopsBaseUrl: 'https://vault.revops.io',
@@ -32,30 +32,30 @@ const local = {
   vaultId: 'tnt6ryfiprp',
   baseUrl: `https://${document.location.host}`,
   serviceName: 'revops-js-local',
-}
+})
 
-const configurations = {
-  "production": production,
-  "staging": staging,
-  "localhost": local
-}
+const getConfigurations = () => ({
+  "production": getProduction(),
+  "staging": getStaging(),
+  "localhost": getLocal(),
+})
 
 const selectConfiguration = () => {
 
   // For testing
   if(!!document !== true || !!document.domain !== true) {
-    return configurations['localhost']
+    return getConfigurations['localhost']
   }
 
   if(document.domain.endsWith('staging.bill.sh')) {
-    return configurations['staging']
+    return getConfigurations['staging']
   } else if (document.domain.endsWith('localhost')) {
-    return configurations['localhost']
+    return getConfigurations['localhost']
   }
 
-  return configurations['production']
+  return getConfigurations['production']
 }
 
-const config = selectConfiguration()
+const getConfig = selectConfiguration
 
-export default config
+export default getConfig;

--- a/src/index.js
+++ b/src/index.js
@@ -44,5 +44,7 @@ export { default as AddressForm } from './AddressForm'
 export { default as Wrapper } from './Wrapper'
 export { default as SignUp } from './SignUp'
 
-styleDependencies.forEach(stylesheet => addStylesheet(stylesheet))
-jsDependencies.forEach(js => addJS(js))
+export const initRevops = () => {
+  styleDependencies.forEach(stylesheet => addStylesheet(stylesheet));
+  jsDependencies.forEach(js => addJS(js));
+}

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -6,13 +6,6 @@ import {
 } from './index'
 
 export class Account extends EntityModel {
-  id: string
-  externalId: string
-  name: string
-  billingContact: BillingContact
-  shippingContact: ShippingContact
-  billingPreferences: BillingPreferences
-
   constructor(params = {}) {
     super(params)
     Object.keys(params).map(attrName =>

--- a/src/models/BillingContact.js
+++ b/src/models/BillingContact.js
@@ -3,12 +3,6 @@ import {
 } from './index'
 
 export class BillingContact extends EntityModel {
-  id: string
-  email: string
-  name: string
-  phone: string
-  title: string
-
   constructor(params = {}) {
     super(params)
     Object.keys(params).map(attrName =>

--- a/src/models/BillingPreferences.js
+++ b/src/models/BillingPreferences.js
@@ -3,21 +3,6 @@ import {
 } from './index'
 
 export class BillingPreferences extends EntityModel {
-  plaidLinkPublicToken: string
-  bankAccountHolderName: string
-  bankAccountHolderType: string
-  bankAccountNumber: string
-  bankCountry: string
-  bankName: string
-  bankRoutingNumber: string
-  cardCvv: string
-  cardExpdate: string
-  cardName: string
-  cardNumber: string
-  cardToken: string
-  id: string
-  paymentMethod: string
-
   constructor(params = {}) {
     super(params)
     Object.keys(params).map(attrName =>

--- a/src/models/EntityModel.js
+++ b/src/models/EntityModel.js
@@ -4,10 +4,6 @@ import uuidv4 from 'uuid/v4'
 import { EntityDate } from './index'
 
 export class EntityModel {
-
-  dateUpdated: string
-  dateCreated: string
-
   constructor(params = {}) {
     this.id = params.id || this._generateUUID()
     this.dateUpdated = params.dateUpdated || new EntityDate().toIsoString()

--- a/src/models/ShippingContact.js
+++ b/src/models/ShippingContact.js
@@ -3,9 +3,6 @@ import {
 } from './index'
 
 export class ShippingContact extends EntityModel {
-  id: string
-  friendlyName: string
-
   constructor(params = {}) {
     super(params)
     Object.keys(params).map(attrName =>


### PR DESCRIPTION
* Change every dependency of window or document to be exported in runtime functions so that SSR works. This happened in src/index and src/client/VaultConfig. I added an initRevops method in src/index that our application can call to instantiate the JavaScript dependencies.
* Remove every instance of the : string syntax which is not valid JavaScript so this compiles. (edited) 