### PR TITLE
Add sandbox mode support through new `apiOptions` prop on PaymentMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ class SignupForm extends Component {
   onValidationError = () => {
     console.warn('Validation Error')
   }
-  
+
   onError = (error) => {
     console.error(error)
   }
@@ -174,7 +174,7 @@ Here is an example how to style inputs:
       background: '#ffffff',
       border: `2px solid papayawhip`
     },
-    '&::placeholder': { 
+    '&::placeholder': {
       color: '#ccc',
     },
   }}
@@ -194,7 +194,7 @@ Here is an example how to style inputs:
 | defaultMethod | PropTypes.oneOf(['ach', 'card', 'plaid']) | The payment method shown first.
 | saveRef | PropTypes.shape({ current: PropTypes.any }) | Assign a ref to add an external save button. If assigned, it will hide built-in buttons.
 | styles | PropTypes.object | Inline CSS Style definition to customize the form.
-
+| apiConfig | PropTypes.object | Optional configuration properties that you can use to override a specific environment, or select a different api environment. Example: `apiConfig={{ env: 'sandbox' }}`. See API Configuration for more info. |
 
 
 ## Account Object `<PaymentMethod account={{ ... }} />`
@@ -257,15 +257,39 @@ account = {
 
 
 ## Available Callbacks
-Revops-js provides callbacks that can be used to implement custom validation or error handling. They are particularly useful when you need to keep branding consistent or need to integrate revops-js with an existing application. 
+Revops-js provides callbacks that can be used to implement custom validation or error handling. They are particularly useful when you need to keep branding consistent or need to integrate revops-js with an existing application.
 
-### `onComplete` 
-This callback is triggered when the revops-js component successfully submits its information and returns the [Account Object](#Account-Object-`<PaymentMethod-account={{-...-}}-/>`) that has been created. 
+### `onComplete`
+This callback is triggered when the revops-js component successfully submits its information and returns the [Account Object](#Account-Object-`<PaymentMethod-account={{-...-}}-/>`) that has been created.
 
-This is the ideal time to capture and extend the data model for your specific needs. 
+This is the ideal time to capture and extend the data model for your specific needs.
 
 ### `onValidationError`
 This callback returns the form's state when a validation error is detected. Validation errors are handled locally and are not submitted to the server. This is useful in larger workflows where the next step is dependent on the success of the previous one.
+
+
+## Advanced configurations
+
+If you want to test in a sandbox environment locally, you can enable, we recommend adding `apiConfig` property to `<PaymentMethod />`
+
+**Example**
+To use the `sandbox` mode for integrations like Plaid, set an apiKey and apiConfig to sandbox.
+```jsx
+<PaymentMethod
+  apiKey="pk_sandbox_xxxxxxxxxxxxxxxxxxxxxxxxx"
+  apiConfig={{
+    env: 'sandbox',
+  }}
+/>
+```
+
+### API Configuration `apiConfig={{ }}`
+
+| Prop     |      type      |  Description |  
+|------------------|:--------------:|-------------:|
+| name    | PropTypes.string | RevOps environment name. Options are `sandbox`, `production`. |
+| plaidEnvironment    | PropTypes.string | Options are `sandbox`, `development`, and `production`. See [Plaid environments overview](https://support.plaid.com/hc/en-us/articles/360010407233-Plaid-environments-overview). |
+
 
 #### Validation Error Properties
 
@@ -291,7 +315,7 @@ __Example Validation Error__
     "isValid": false,
     "name": "billing_preferences.cardNumber",
     "elementId": "card-number"
-  }, 
+  },
   /*...*/
 }
 ```
@@ -324,10 +348,10 @@ __Additional HTTP Statuses__
 | 400  | RevOps API bad request.
 | 401  | RevOps API access denied. Update your `publicKey`.
 | 404  | The requested resource doesn't exist.
-| 500s | Server errors, contact [RevOps](https://revops.io) for assistance. 
- 
+| 500s | Server errors, contact [RevOps](https://revops.io) for assistance.
 
-### Callback Example 
+
+### Callback Example
 
 ```jsx
 import React, { Component } from 'react'
@@ -342,11 +366,11 @@ class App extends Component {
 
   // this callback is called when an error occurs in revops-js
   onError = (error) => {
-    let errorMsg =  'Please contact support' 
+    let errorMsg =  'Please contact support'
     if (error.http_status < 500) {
       errorMsg = error.message
     }
-    this.setState({error: true, errorMsg}) 
+    this.setState({error: true, errorMsg})
   }
 
   // If you'd like to save the data on your own platform in a PII-safe way, use the response object.
@@ -387,9 +411,9 @@ class App extends Component {
 ```
 
 ## Using a React Ref to Submit Form
-Let's talk about how to integrate revops.js into a larger workflow using [React Refs](https://reactjs.org/docs/refs-and-the-dom.html) to control the revops child component. First, we need to define the `saveRef` property. This is done in two parts. 
+Let's talk about how to integrate revops.js into a larger workflow using [React Refs](https://reactjs.org/docs/refs-and-the-dom.html) to control the revops child component. First, we need to define the `saveRef` property. This is done in two parts.
 
-First, define the ref to pass down to the component. 
+First, define the ref to pass down to the component.
 ```jsx
 class SignupForm extends Component {
   constructor(props) {
@@ -465,7 +489,8 @@ class SignupForm extends Component {
 }
 ```
 
-Now we can now control the submission process of the `<PaymentMethod />` component from its parent component as one unified workflow. 
+Now we can now control the submission process of the `<PaymentMethod />` component from its parent component as one unified workflow.
+
 
 ## License
 

--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -14,8 +14,6 @@ import {
   Field,
   TogglePlaid,
   configureVault,
-  jsDependencies,
-  addJS,
 } from './index'
 
 import configure from './client/VaultConfig'
@@ -75,9 +73,6 @@ export default class AchForm extends Component {
     /** Color of error text, a valid color name or hex. */
     errorColor: PropTypes.string,
 
-    /** Internal Use-only: Environment string: local, staging, production */
-    env: PropTypes.string,
-
     /** Internal Use-only: Change payment method swaps current payment method state */
     changePaymentMethod: PropTypes.func,
 
@@ -113,9 +108,8 @@ export default class AchForm extends Component {
   }
 
   componentDidMount() {
-    jsDependencies.forEach(js => addJS(js))
     configureVault(
-      this.props.env,
+      this.props.apiConfig,
       this.initialize,
     )
   }
@@ -149,8 +143,10 @@ export default class AchForm extends Component {
     const { account } = this.props
 
     if(!!this.form === false) {
+      let conf = configure(this.props.apiOptions)
+
       // eslint-disable-next-line
-      this.form = VGSCollect.create(configure(this.props.env).vaultId, function () { });
+      this.form = VGSCollect.create(conf.vaultId, function () { });
     }
 
     this.initForm('bank-name',

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -18,8 +18,6 @@ import { linkStyling } from './SharedStyles'
 
 import {
   Field,
-  jsDependencies,
-  addJS,
   configureVault,
 } from './index'
 
@@ -75,11 +73,11 @@ export default class CreditCardForm extends Component {
     /** Color of error text, a valid color name or hex. */
     errorColor: PropTypes.string,
 
-    /** Internal Use-only: Environment string: local, staging, production */
-    env: PropTypes.string,
-
     /** Internal Use-only: Change payment method swaps current payment method state */
     changePaymentMethod: PropTypes.func,
+
+    /** Optional API Options **/
+    apiOptions: PropTypes.object,
   }
 
   static defaultProps = {
@@ -108,10 +106,8 @@ export default class CreditCardForm extends Component {
   }
 
   componentDidMount() {
-    jsDependencies.forEach(js => addJS(js))
-
     configureVault(
-      this.props.env,
+      this.props.apiOptions,
       this.initialize,
     )
   }
@@ -125,8 +121,9 @@ export default class CreditCardForm extends Component {
   initialize = () => {
     const { account } = this.props
 
+    let conf = configure(this.props.apiOptions)
     // eslint-disable-next-line
-    const form = VGSCollect.create(configure(this.props.env).vaultId, function (state) { });
+    const form = VGSCollect.create(conf.vaultId, function (state) { });
 
     this.initForm('card-name',
       () => form.field("#card-name .field-space", {

--- a/src/PaymentMethod.d.ts
+++ b/src/PaymentMethod.d.ts
@@ -9,6 +9,7 @@ enum PaymentMethods {
 
 export interface PaymentMethodProps {
   static propTypes = {
+
     /** Required RevOps API Public Key **/
     publicKey: string,
 
@@ -53,6 +54,9 @@ export interface PaymentMethodProps {
 
     /** Account object allows preconfigured account options to be set */
     account?: object,
+
+    /** Optional API Options **/
+    apiOptions?: object,
   }
 }
 

--- a/src/PaymentMethod.js
+++ b/src/PaymentMethod.js
@@ -7,8 +7,6 @@ import {
   CreditCardForm,
   PlaidForm,
   AchForm,
-  jsDependencies,
-  addJS,
 } from './index'
 
 import { ButtonGroup } from './ButtonGroup'
@@ -87,6 +85,9 @@ export default class PaymentMethod extends Component {
 
     /** Render customized ACH forms */
     renderAchForms: PropTypes.func,
+
+    /** Optional API Options **/
+    apiOptions: PropTypes.object,
   }
 
 
@@ -131,7 +132,6 @@ export default class PaymentMethod extends Component {
   }
 
   componentDidMount() {
-    jsDependencies.forEach(js => addJS(js))
     this.initializeAccount()
   }
 

--- a/src/PlaidForm.js
+++ b/src/PlaidForm.js
@@ -15,8 +15,6 @@ import {
   TogglePlaid,
   configureVault,
   configurePlaid,
-  jsDependencies,
-  addJS,
 } from './index'
 
 import configure from './client/VaultConfig'
@@ -69,14 +67,14 @@ export default class PlaidForm extends Component {
     /** Color of error text, a valid color name or hex. */
     errorColor: PropTypes.string,
 
-    /** Internal Use-only: Environment string: local, staging, production */
-    env: PropTypes.string,
-
     /** Internal Use-only: Change payment method swaps current payment method state */
     changePaymentMethod: PropTypes.func,
 
     /** Optional reference to allow your own save buttons */
     saveRef: PropTypes.shape({ current: PropTypes.any }),
+
+    /** Optional API Options **/
+    apiOptions: PropTypes.object,
   }
 
   static defaultProps = {
@@ -104,9 +102,8 @@ export default class PlaidForm extends Component {
   }
 
   componentDidMount() {
-    jsDependencies.forEach(js => addJS(js))
     configureVault(
-      this.props.env,
+      this.props.apiConfig,
       this.initialize,
     )
 

--- a/src/client/VaultConfig.js
+++ b/src/client/VaultConfig.js
@@ -1,31 +1,52 @@
+const ENV_PRODUCTION = 'production'
+const ENV_SANDBOX = 'sandbox'
+
 const production = () => ({
-  name: 'production',
+  name: ENV_PRODUCTION,
   vaultCollectUrl: 'https://js.verygoodvault.com/vgs-collect/1/ACvYkoDARh7Ajf3DhktqckgY.js',
   revopsBaseUrl: 'https://vault.revops.io',
   plaidUrl: 'https://cdn.plaid.com/link/v2/stable/link-initialize.js',
-  plaidEnvironment: 'development', // production when we are ready
+  plaidEnvironment: ENV_PRODUCTION, // production when we are ready
   plaidKey: 'c648203cbd9ce4b7ea39f26c61f115',
   vaultId: 'tnt2w1xznia',
   baseUrl: `https://${document.location.host}`,
   serviceName: 'revops-js-production',
 })
 
+const sandbox = () => ({
+  name: ENV_SANDBOX,
+  vaultCollectUrl: 'https://js.verygoodvault.com/vgs-collect/1/ACvYkoDARh7Ajf3DhktqckgY.js',
+  revopsBaseUrl: 'https://vault.revops.io',
+  plaidUrl: 'https://cdn.plaid.com/link/v2/stable/link-initialize.js',
+  plaidEnvironment: ENV_SANDBOX, // production when we are ready
+  plaidKey: 'c648203cbd9ce4b7ea39f26c61f115',
+  vaultId: 'tnt2w1xznia',
+  baseUrl: `https://${document.location.host}`,
+  serviceName: 'revops-js-production',
+})
 
 const configurations = () => ({
   "production": production(),
+  "sandbox": sandbox(),
 })
 
-export const configure = (env = false) => {
+export const configure = (apiOptions = {
+  env: ENV_PRODUCTION,
+}) => {
   let environments = configurations()
-  if (env !== false) {
-    if (!!environments[env] === false) {
+  let env = ENV_PRODUCTION
+  if (!!apiOptions.env !== false) {
+    if (!!environments[apiOptions.env] === false) {
       throw new Error("Unable to locate environment selected: ", env)
     }
 
-    return environments[env]
+    env = apiOptions.env
   }
 
-  return environments['production']
+  return {
+    ...environments[env],
+    ...apiOptions,
+  }
 }
 
 export default configure

--- a/src/index.js
+++ b/src/index.js
@@ -1,40 +1,13 @@
 import configure from './client/VaultConfig'
 
-export const styleDependencies = [
-  // "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css",
-  // "https://use.fontawesome.com/releases/v5.7.2/css/all.css",
-]
-
-export const jsDependencies = [
-  "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.slim.min.js",
-  "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.js",
-]
-
-export const addStylesheet = (url) => {
-  const link = document.createElement("link")
-  link.href = url
-  link.rel = "stylesheet"
-  link.crossorigin = "anonymous"
-  document.body.appendChild(link);
-}
-
-export const addJS = (url, onload = () => {}) => {
-  const script = document.createElement("script")
-
-  script.src = url
-  script.async = true
-  script.onload = () => {
-    onload()
-  }
-  document.body.appendChild(script);
-}
-
 /* configureVault
  * @param env - string - options are local, staging, production.
  * @param onLoad - function - called when vault is loaded.
  */
 export const configureVault = (
-  env = false,
+  apiOptions = {
+    env: 'production',
+  },
   onLoad: false,
 ) => {
   if (!!window !== true && !!document !== true) {
@@ -42,7 +15,7 @@ export const configureVault = (
   }
 
   const script = document.createElement("script")
-  script.src = configure(env).vaultCollectUrl
+  script.src = configure(apiOptions).vaultCollectUrl
   script.async = true
   script.onload = onLoad
 


### PR DESCRIPTION
## Advanced configurations

If you want to test in a sandbox environment locally, you can enable, we recommend adding `apiConfig` property to `<PaymentMethod />`

**Example**
To use the `sandbox` mode for integrations like Plaid, set an apiKey and apiConfig to sandbox.
```jsx
<PaymentMethod
  apiKey="pk_sandbox_xxxxxxxxxxxxxxxxxxxxxxxxx"
  apiConfig={{
    env: 'sandbox',
  }}
/>
```

### API Configuration `apiConfig={{ }}`

| Prop     |      type      |  Description |  
|------------------|:--------------:|-------------:|
| name    | PropTypes.string | RevOps environment name. Options are `sandbox`, `production`. |
| plaidEnvironment    | PropTypes.string | Options are `sandbox`, `development`, and `production`. See [Plaid environments overview](https://support.plaid.com/hc/en-us/articles/360010407233-Plaid-environments-overview). |
