### PR TITLE
Migrate from PUT /v1/accounts/:id to POST  /v1/accounts 

### DIFF
--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -53,7 +53,7 @@ export class Account extends EntityModel {
     if (!!apiKey === false || apiKey.startsWith('pk_') === false) {
       throw new Error("Unable to call save. Empty `apiKey`, make sure you have set your publicKey prop.")
     }
-    form.submit(`/v1/accounts/${this.id}`,
+    form.submit(`/v1/accounts`,
       {
         headers: {
           'X-RevOps-Client': 'RevOps-JS',

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -7,6 +7,8 @@ import {
 
 import _ from 'lodash'
 
+const ACCOUNTS_LIST_RESOURCE = '/v1/accounts'
+
 export class Account extends EntityModel {
   accountId = ""
   name = ""
@@ -53,7 +55,7 @@ export class Account extends EntityModel {
     if (!!apiKey === false || apiKey.startsWith('pk_') === false) {
       throw new Error("Unable to call save. Empty `apiKey`, make sure you have set your publicKey prop.")
     }
-    form.submit(`/v1/accounts`,
+    form.submit(ACCOUNTS_LIST_RESOURCE,
       {
         headers: {
           'X-RevOps-Client': 'RevOps-JS',


### PR DESCRIPTION
We identified a developer frustration with creating duplicate accounts. The behavior of PUT is to change the /v1/accounts/:id resource when providing the correct :id. But if an account already exists by the email provided on another :id, this causes it to update the originating account. This can have an inadvertent effect of redirecting the user to a different URI.

We've decided that this is confusing behavior and isn't restful enough. If you're creating a new account, always use a POST /v1/accounts from now on. 