### PR TITLE
Updated rollup config to support async await

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "engines": {
     "node": ">=8",
     "npm": ">=5"
-  }, 
+  },
   "scripts": {
     "test": "cross-env CI=1 react-scripts test --env=jsdom",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
@@ -68,6 +68,7 @@
     "themes"
   ],
   "dependencies": {
+    "babel-plugin-transform-runtime": "^6.23.0",
     "lodash": "^4.17.15",
     "react-plaid-link": "^1.5.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,8 +32,9 @@ export default {
     url(),
     svgr(),
     babel({
+      runtimeHelpers: true,
       exclude: 'node_modules/**',
-      plugins: ['external-helpers']
+      plugins: ['external-helpers', 'transform-runtime']
     }),
     resolve({
       browser: true


### PR DESCRIPTION
Modified the rollup configuration to support the use of async-await. 

Related: https://github.com/rollup/rollup-plugin-babel/issues/209