### PR TITLE
WIP: add method prop to payment method

### DIFF
--- a/src/PaymentMethod.js
+++ b/src/PaymentMethod.js
@@ -103,6 +103,9 @@ export default class PaymentMethod extends Component {
 
     /** Optional API Options **/
     apiOptions: PropTypes.object,
+
+    /** used to set the current method, overrides internal method state */
+    method: PropTypes.oneOf(Object.values(PaymentMethods)),
   }
 
   static defaultProps = {
@@ -161,7 +164,6 @@ export default class PaymentMethod extends Component {
     this.setAccount(account)
 
     this.setState({ isUpdate })
-    
 
     if (!!instrument === false) {
       this.setState({ instrument: new Instrument({}) })
@@ -196,9 +198,9 @@ export default class PaymentMethod extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { account, instrument } = this.props
+    const { account, instrument, method } = this.props
     if (
-      !!prevProps.account !== false && 
+      !!prevProps.account !== false &&
       !!account !== false &&
       prevProps.account !== account
     ) {
@@ -206,11 +208,15 @@ export default class PaymentMethod extends Component {
     }
 
     if (
-      !!prevProps.instrument !== false && 
+      !!prevProps.instrument !== false &&
       !!instrument !== false &&
       prevProps.instrument !== instrument
     ) {
       this.setState({ instrument: new Instrument(instrument) })
+    }
+
+    if (prevProps.method !== method) {
+      this.setState({ method })
     }
   }
 

--- a/src/PaymentMethod.test.js
+++ b/src/PaymentMethod.test.js
@@ -190,4 +190,18 @@ describe('The PaymentMethod Component', () => {
       expect(wrapper.instance().state.accountModel.accountId).to.equal('existing-acct')
     })
   })
+
+  describe('toggling the explicit method prop', () => {
+    it('Should update internal "method" when the "method" prop changes', () => {
+      const mockProps = generateMockProps({
+        method: 'ach'
+      })
+      const wrapper = shallow(<PaymentMethod  {...mockProps} />)
+      expect(wrapper.instance().state.method).to.equal('ach')
+
+      wrapper.setProps({method: 'credit-card'})
+      expect(wrapper.instance().state.method).to.equal('credit-card')
+    })
+  })
+  
 })


### PR DESCRIPTION
The addition of the `method` property allows the developer to control the current method of the `<PaymentMethod />` component.