### PR TITLE
WIP: override props

### DIFF
--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -18,6 +18,10 @@ import {
   configureVault,
 } from './index'
 
+import {
+  PropertyHelper,
+} from './helpers/PropHelpers'
+
 import { Instrument, Account } from './models'
 
 import configure from './client/VaultConfig'
@@ -105,6 +109,25 @@ export default class AchForm extends Component {
 
     /** tells the component to create an account with the instrument */
     createAccount: PropTypes.bool,
+
+    /**
+     * overrideProps is an object where keys names are ids of the particular 
+     * element in the DOM. `<div id="bank-name" > = "bank-name": {}`. 
+     * Only allowed properties are passed see 
+     */
+    overrideProps: PropTypes.shape({
+      css: PropTypes.object, // CSS in JS
+      placeholder: PropTypes.string,
+      color: PropTypes.string,
+      errorColor: PropTypes.string,
+      showCardLink: PropTypes.bool, // some fields only
+      label: PropTypes.string,
+      options: PropTypes.arrayOf( // select lists only
+        PropTypes.shape({
+          value: PropTypes.string,
+          text: PropTypes.string
+      }))
+    })
   }
 
   static defaultProps = {
@@ -118,16 +141,12 @@ export default class AchForm extends Component {
     errorColor: SharedStyles.errorColor,
   }
 
-  state = {
-    account: {},
-    errors: false,
-    loaded: false,
-  }
-
   constructor(props) {
     super(props)
     this.state = {
+      account: {},
       errors: false,
+      loaded: false,
     }
     this.form = null
   }
@@ -188,7 +207,14 @@ export default class AchForm extends Component {
   }
 
   initialize = () => {
-    const { instrument, createAccount = false } = this.props
+    const { 
+      instrument, 
+      createAccount = false ,
+      inputStyles = {},
+      overrideProps = {},
+    } = this.props
+    
+    const propHelper = new PropertyHelper(overrideProps, inputStyles)
 
     if (!!this.form === false) {
       let conf = configure(this.props.apiOptions)
@@ -197,7 +223,7 @@ export default class AchForm extends Component {
       this.form = VGSCollect.create(conf.vaultId, function () { });
     }
     const prefix = createAccount === true ? "instrument." : ""
-
+    
     this.initForm('bank-name',
       () => this.createFormField(
         "#bank-name .field-space",
@@ -207,8 +233,10 @@ export default class AchForm extends Component {
           type: "text",
           placeholder: "Name of Bank Institution",
           validations: ["required"],
-        }
+          ...propHelper.overrideCollectProps('bank-name'),
+        },
       ))
+
     this.initForm('bank-postalcode',
       () => this.createFormField(
         "#bank-postalcode .field-space",
@@ -218,8 +246,10 @@ export default class AchForm extends Component {
           type: "zip-code",
           placeholder: "Postal code",
           validations: ["required"],
-        }
+          ...propHelper.overrideCollectProps('bank-postalcode'),
+        },
       ))
+
     this.initForm('bank-account-country',
       () => this.createFormField(
         "#bank-account-country .field-space",
@@ -233,6 +263,7 @@ export default class AchForm extends Component {
             { value: 'Canada', text: 'Canada' },
             { value: 'Mexico', text: 'Mexico' },
           ],
+          ...propHelper.overrideCollectProps('bank-account-country', ["options"]),
         })
     )
 
@@ -245,7 +276,8 @@ export default class AchForm extends Component {
           type: "text",
           placeholder: "Name on the account",
           validations: ["required"],
-        }
+          ...propHelper.overrideCollectProps('bank-holder-name'),
+        },
       ))
 
     this.initForm('bank-account-type',
@@ -260,7 +292,8 @@ export default class AchForm extends Component {
             { value: 'company', text: 'Company' },
             { value: 'individual', text: 'Individual' },
           ],
-        }
+          ...propHelper.overrideCollectProps('bank-account-type', ["options"]),
+        }, 
       ))
 
     this.initForm('bank-account-number',
@@ -272,7 +305,8 @@ export default class AchForm extends Component {
           type: "text",
           placeholder: "Enter bank account number",
           validations: ["required"],
-        }
+          ...propHelper.overrideCollectProps('bank-account-number')
+        },
       ))
 
     this.initForm('bank-routing-number', () =>
@@ -284,7 +318,8 @@ export default class AchForm extends Component {
           type: "text",
           placeholder: "Enter bank routing number",
           validations: ["required"],
-        }
+          ...propHelper.overrideCollectProps('bank-routing-number')
+        },
       )
     )
   }
@@ -403,7 +438,10 @@ export default class AchForm extends Component {
       instrument,
       sectionStyle,
       cardWidth = false,
+      overrideProps = {},
     } = this.props
+
+    const propHelper = new PropertyHelper(overrideProps)
 
     return (
       <section style={!!cardWidth === true ? cardWidth : sectionStyle}>
@@ -433,6 +471,7 @@ export default class AchForm extends Component {
                 defaultValue={getDefaultValue(instrument, 'bankName', '')}
                 showInlineError={true}
                 errors={errors}
+                {...propHelper.overrideFieldProps("bank-name")}
               />
 
               <Field
@@ -442,6 +481,7 @@ export default class AchForm extends Component {
                 defaultValue={getDefaultValue(instrument, 'bankAccountHolderName', '')}
                 showInlineError={true}
                 errors={errors}
+                {...propHelper.overrideFieldProps("bank-holder-name")}
               />
 
               <Field
@@ -451,6 +491,7 @@ export default class AchForm extends Component {
                 defaultValue={getDefaultValue(instrument, 'postalcode', '')}
                 showInlineError={true}
                 errors={errors}
+                {...propHelper.overrideFieldProps("bank-postalcode")}
               />
 
               <Field
@@ -460,6 +501,7 @@ export default class AchForm extends Component {
                 defaultValue={getDefaultValue(instrument, 'country', '')}
                 showInlineError={true}
                 errors={errors}
+                {...propHelper.overrideFieldProps("bank-account-country")}
               />
 
               <Field
@@ -469,6 +511,7 @@ export default class AchForm extends Component {
                 defaultValue={getDefaultValue(instrument, 'accountHolderType', '')}
                 showInlineError={true}
                 errors={errors}
+                {...propHelper.overrideFieldProps("bank-account-type")}
               />
 
               <Field
@@ -478,6 +521,7 @@ export default class AchForm extends Component {
                 defaultValue={getDefaultValue(instrument, 'routingNumber', '')}
                 showInlineError={true}
                 errors={errors}
+                {...propHelper.overrideFieldProps("bank-routing-number")}
               />
 
               <Field
@@ -487,6 +531,7 @@ export default class AchForm extends Component {
                 defaultValue={getDefaultValue(instrument, 'accountNumber', '')}
                 showInlineError={true}
                 errors={errors}
+                {...propHelper.overrideFieldProps("bank-account-number")}
               />
             </React.Fragment>
           }

--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -263,7 +263,7 @@ export default class AchForm extends Component {
             { value: 'Canada', text: 'Canada' },
             { value: 'Mexico', text: 'Mexico' },
           ],
-          ...propHelper.overrideCollectProps('bank-account-country', ["options"]),
+          ...propHelper.overrideCollectProps('bank-account-country'),
         })
     )
 
@@ -292,7 +292,7 @@ export default class AchForm extends Component {
             { value: 'company', text: 'Company' },
             { value: 'individual', text: 'Individual' },
           ],
-          ...propHelper.overrideCollectProps('bank-account-type', ["options"]),
+          ...propHelper.overrideCollectProps('bank-account-type'),
         }, 
       ))
 

--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -113,7 +113,7 @@ export default class AchForm extends Component {
     /**
      * overrideProps is an object where keys names are ids of the particular 
      * element in the DOM. `<div id="bank-name" > = "bank-name": {}`. 
-     * Only allowed properties are passed see 
+     * Only allowed properties are allowed, see https://github.com/revops-io/revops.js/wiki/Using-Override-Props
      */
     overrideProps: PropTypes.shape({
       css: PropTypes.object, // CSS in JS
@@ -122,11 +122,6 @@ export default class AchForm extends Component {
       errorColor: PropTypes.string,
       showCardLink: PropTypes.bool, // some fields only
       label: PropTypes.string,
-      options: PropTypes.arrayOf( // select lists only
-        PropTypes.shape({
-          value: PropTypes.string,
-          text: PropTypes.string
-      }))
     })
   }
 

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types'
 
 import { submitForm, getToken } from './actions/FormActions'
 
+import {
+  PropertyHelper,
+} from './helpers/PropHelpers'
+
 import { makeAccount } from './actions/AccountActions'
 import {
   getErrorText,
@@ -83,7 +87,7 @@ export default class CreditCardForm extends Component {
 
     /** Optional API Options **/
     apiOptions: PropTypes.object,
-    
+
     /** 
      * a token that grants permission to interact with the RevOps API 
      * takes the place of the public key when performing secure operations 
@@ -100,6 +104,25 @@ export default class CreditCardForm extends Component {
 
     /** tells the component to create an account with the instrument */
     createAccount: PropTypes.bool,
+
+    /**
+     * overrideProps is an object where keys names are ids of the particular 
+     * element in the DOM. `<div id="bank-name" > = "bank-name": {}`. 
+     * Only allowed properties are passed see 
+     */
+    overrideProps: PropTypes.shape({
+      css: PropTypes.object, // CSS in JS
+      placeholder: PropTypes.string,
+      color: PropTypes.string,
+      errorColor: PropTypes.string,
+      showCardLink: PropTypes.bool, // some fields only
+      label: PropTypes.string,
+      options: PropTypes.arrayOf( // select lists only
+        PropTypes.shape({
+          value: PropTypes.string,
+          text: PropTypes.string
+      }))
+    })
 
   }
 
@@ -120,7 +143,7 @@ export default class CreditCardForm extends Component {
       errors: false,
       status: false,
       response: false,
-  
+
     }
     this.form = {};
   }
@@ -160,12 +183,20 @@ export default class CreditCardForm extends Component {
   }
 
   initialize = () => {
-    const { instrument, createAccount = false } = this.props
+    const {
+      instrument,
+      createAccount = false,
+      inputStyles,
+      overrideProps = {},
+    } = this.props
     let conf = configure(this.props.apiOptions)
+
+    const propHelper = new PropertyHelper(overrideProps, inputStyles)
 
     // eslint-disable-next-line
     const form = VGSCollect.create(conf.vaultId, function (state) { });
     const prefix = createAccount === true ? "instrument." : ""
+
     this.initForm('card-name',
       () => form.field("#card-name .field-space", {
         type: "text",
@@ -175,6 +206,7 @@ export default class CreditCardForm extends Component {
         placeholder: "Florence Izote",
         validations: ["required"],
         css: this.props.inputStyles,
+        ...propHelper.overrideCollectProps('card-name'),
       })
     )
 
@@ -189,6 +221,7 @@ export default class CreditCardForm extends Component {
         showCardIcon: true,
         autoComplete: 'card-number',
         css: this.props.inputStyles,
+        ...propHelper.overrideCollectProps('card-number', ["showCardIcon"]),
       })
     )
 
@@ -201,6 +234,7 @@ export default class CreditCardForm extends Component {
         placeholder: "311",
         validations: ["required", "validCardSecurityCode"],
         css: this.props.inputStyles,
+        ...propHelper.overrideCollectProps('card-cvc'),
       })
     )
 
@@ -210,7 +244,7 @@ export default class CreditCardForm extends Component {
         name: prefix + 'card_expdate',
         errorColor: this.props.errorColor,
         placeholder: "01 / 2022",
-        defaultValue: getDefaultCardExpDate(instrument),
+        defaultValue: getDefaultCardExpDate(instrument, inputStyles),
         serializers: [
           form.SERIALIZERS.separate({
             monthName: 'month',
@@ -219,6 +253,7 @@ export default class CreditCardForm extends Component {
         ],
         validations: ["required", "validCardExpirationDate"],
         css: this.props.inputStyles,
+        ...propHelper.overrideCollectProps('card-expdate'),
       })
     )
 
@@ -231,6 +266,7 @@ export default class CreditCardForm extends Component {
         placeholder: "Postal code",
         validations: ["required"],
         css: this.props.inputStyles,
+        ...propHelper.overrideCollectProps('card-postalcode'),
       })
     )
 
@@ -347,7 +383,10 @@ export default class CreditCardForm extends Component {
       instrument,
       sectionStyle,
       cardWidth = false,
+      overrideProps = {},
     } = this.props
+
+    const propHelper = new PropertyHelper(overrideProps)
 
     return (
       <section style={!!cardWidth === true ? cardWidth : sectionStyle}>
@@ -377,8 +416,9 @@ export default class CreditCardForm extends Component {
                   defaultValue={getDefaultValue(instrument, 'cardName', '')}
                   showInlineError={true}
                   errors={errors}
+                  {...propHelper.overrideFieldProps("card-name")}
                 />
-                
+
                 <Field
                   id="card-number"
                   name="cardNumber"
@@ -386,6 +426,7 @@ export default class CreditCardForm extends Component {
                   defaultValue={getDefaultValue(instrument, 'cardNumber', '')}
                   showInlineError={true}
                   errors={errors}
+                  {...propHelper.overrideFieldProps("card-number")}
                 />
 
                 <Field
@@ -395,6 +436,7 @@ export default class CreditCardForm extends Component {
                   defaultValue={getDefaultValue(instrument, 'cardExpdate', '')}
                   showInlineError={true}
                   errors={errors}
+                  {...propHelper.overrideFieldProps("card-expdate")}
                 />
 
                 <Field
@@ -404,6 +446,7 @@ export default class CreditCardForm extends Component {
                   defaultValue={getDefaultValue(instrument, 'cardCvv', '')}
                   showInlineError={true}
                   errors={errors}
+                  {...propHelper.overrideFieldProps("card-cvc")}
                 />
 
                 <Field
@@ -413,6 +456,7 @@ export default class CreditCardForm extends Component {
                   defaultValue={getDefaultValue(instrument, 'postalCode', '')}
                   showInlineError={true}
                   errors={errors}
+                  {...propHelper.overrideFieldProps("card-postalcode")}
                 />
               </React.Fragment>
             }

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -108,7 +108,7 @@ export default class CreditCardForm extends Component {
     /**
      * overrideProps is an object where keys names are ids of the particular 
      * element in the DOM. `<div id="bank-name" > = "bank-name": {}`. 
-     * Only allowed properties are passed see 
+     * Only allowed properties are allowed, see https://github.com/revops-io/revops.js/wiki/Using-Override-Props
      */
     overrideProps: PropTypes.shape({
       css: PropTypes.object, // CSS in JS
@@ -117,11 +117,6 @@ export default class CreditCardForm extends Component {
       errorColor: PropTypes.string,
       showCardLink: PropTypes.bool, // some fields only
       label: PropTypes.string,
-      options: PropTypes.arrayOf( // select lists only
-        PropTypes.shape({
-          value: PropTypes.string,
-          text: PropTypes.string
-      }))
     })
 
   }

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -426,7 +426,7 @@ export default class CreditCardForm extends Component {
                   defaultValue={getDefaultValue(instrument, 'cardNumber', '')}
                   showInlineError={true}
                   errors={errors}
-                  {...propHelper.overrideFieldProps("card-number")}
+                  {...propHelper.overrideFieldProps("card-number", ["showCardIcon"])}
                 />
 
                 <Field

--- a/src/SignUp.js
+++ b/src/SignUp.js
@@ -16,6 +16,10 @@ import { ButtonGroup } from './ButtonGroup'
 import * as SharedStyles from './SharedStyles'
 
 import {
+  PropertyHelper,
+} from './helpers/PropHelpers'
+
+import {
   Field,
   configureVault,
 } from './index'
@@ -88,6 +92,25 @@ export class _SignUp extends Component {
 
     /** Deprecated property for controlling the style of the parent component */
     cardWidth: PropTypes.object,
+
+    /**
+     * overrideProps is an object where keys names are ids of the particular 
+     * element in the DOM. `<div id="bank-name" > = "bank-name": {}`. 
+     * Only allowed properties are passed see 
+     */
+    overrideProps: PropTypes.shape({
+      css: PropTypes.object, // CSS in JS
+      placeholder: PropTypes.string,
+      color: PropTypes.string,
+      errorColor: PropTypes.string,
+      showCardLink: PropTypes.bool, // some fields only
+      label: PropTypes.string,
+      options: PropTypes.arrayOf( // select lists only
+        PropTypes.shape({
+          value: PropTypes.string,
+          text: PropTypes.string
+      }))
+    })
   }
 
   componentDidMount() {
@@ -125,11 +148,17 @@ export class _SignUp extends Component {
   }
 
   initialize = () => {
-    const { account } = this.props
+    const { 
+      account,  
+      inputStyles,
+      overrideProps = {},
+    } = this.props
     const conf = configure(this.props.apiOptions)
 
     // eslint-disable-next-line
     const form = VGSCollect.create(conf.vaultId, function (state) { });
+
+    const propHelper = new PropertyHelper(overrideProps, inputStyles)
 
     this.initForm('signup-email',
       () => form.field("#signup-email .field-space", {
@@ -140,6 +169,7 @@ export class _SignUp extends Component {
         placeholder: "you@example.com",
         validations: ["required"],
         css: this.props.inputStyles,
+        ...propHelper.overrideCollectProps('signup-email'),
       })
     )
 
@@ -234,7 +264,10 @@ export class _SignUp extends Component {
       onCancel,
       sectionStyle,
       cardWidth = false,
+      overrideProps = {},
     } = this.props
+
+    const propHelper = new PropertyHelper(overrideProps)
 
     return (
       <section style={!!cardWidth === true ? cardWidth : sectionStyle}>
@@ -246,6 +279,7 @@ export class _SignUp extends Component {
             defaultValue={getDefaultValue(account, 'email', '')}
             showInlineError={true}
             errors={errors}
+            {...propHelper.overrideFieldProps("signup-email")}
           />
         </div>
         <div className="ui clearing divider"></div>
@@ -267,6 +301,9 @@ export class _SignUp extends Component {
   }
 }
 
+/**
+ * We wrap the component so we can apply the ref
+ */
 export const SignUp = (props) => {
   return (
     <_SignUp ref={props.saveRef} {...props} />

--- a/src/actions/FormActions.js
+++ b/src/actions/FormActions.js
@@ -1,17 +1,17 @@
 import { logError, logWarning } from '../helpers/Logger'
 
-export const submitForm = (object, token, form, callbacks, apiOptions = {}, isUpdate) => {
+export function submitForm (object, token, form, callbacks, apiOptions = {}, isUpdate){
   object.saveWithSecureForm(token, form, callbacks, apiOptions, isUpdate)
 }
 
-export const getToken = async ({
+export const getToken =  async function({
   account,
   accessToken,
   getToken,
   publicKey,
   apiOptions = {},
   isUpdate = false
-}) => {
+}) {
   const { loggingLevel = '' } = apiOptions
 
   if (!!accessToken === true && isUpdate === false) {

--- a/src/helpers/PropHelpers.js
+++ b/src/helpers/PropHelpers.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-const iframeOverrideProps = ['placeholder', 'color', 'errorColor', 'css', 'showCardIcon']
+const iframeOverrideProps = ['placeholder', 'color', 'errorColor', 'css']
 const fieldOverrideProps = ['label']
 
 export const overrideCollectProps = (

--- a/src/helpers/PropHelpers.js
+++ b/src/helpers/PropHelpers.js
@@ -3,40 +3,6 @@ import _ from 'lodash'
 const iframeOverrideProps = ['placeholder', 'color', 'errorColor', 'css']
 const fieldOverrideProps = ['label']
 
-export const overrideCollectProps = (
-  propName, 
-  overrideProps, 
-  inputStyles = {},
-  alsoAcceptProps = []
-) => {
-
-  let fieldProps = overrideProps[propName]
-
-  // specific css should merge over inputStyles
-  if(!!fieldProps.css === true){
-    fieldProps = {
-      ...fieldProps,
-      css: {
-        ...inputStyles,
-        ...fieldProps.css,
-      }
-    }
-  }
-
-  return _.pick(fieldProps, iframeOverrideProps.concat(alsoAcceptProps))
-}
-
-export const overrideFieldProps = (
-  propName, 
-  overrideProps, 
-  alsoAcceptProps = []
-) => {
-  return _.pick(
-    overrideProps[propName], 
-    fieldOverrideProps.concat(alsoAcceptProps)
-  )
-}
-
 export class PropertyHelper {
   constructor(overrideProps = {}, inputStyles = {}){
     this.overrideProps = overrideProps

--- a/src/helpers/PropHelpers.js
+++ b/src/helpers/PropHelpers.js
@@ -17,7 +17,7 @@ export class PropertyHelper {
     let currentOverrideProps = this.overrideProps[propName]
 
     // specific css should merge over inputStyles
-    if(!!currentOverrideProps.css === true){
+    if(!!currentOverrideProps === true && !!currentOverrideProps.css === true){
       currentOverrideProps = {
         ...currentOverrideProps,
         css: {

--- a/src/helpers/PropHelpers.js
+++ b/src/helpers/PropHelpers.js
@@ -1,0 +1,79 @@
+import _ from 'lodash'
+
+const iframeOverrideProps = ['placeholder', 'color', 'errorColor', 'css', 'showCardIcon']
+const fieldOverrideProps = ['label']
+
+export const overrideCollectProps = (
+  propName, 
+  overrideProps, 
+  inputStyles = {},
+  alsoAcceptProps = []
+) => {
+
+  let fieldProps = overrideProps[propName]
+
+  // specific css should merge over inputStyles
+  if(!!fieldProps.css === true){
+    fieldProps = {
+      ...fieldProps,
+      css: {
+        ...inputStyles,
+        ...fieldProps.css,
+      }
+    }
+  }
+
+  return _.pick(fieldProps, iframeOverrideProps.concat(alsoAcceptProps))
+}
+
+export const overrideFieldProps = (
+  propName, 
+  overrideProps, 
+  alsoAcceptProps = []
+) => {
+  return _.pick(
+    overrideProps[propName], 
+    fieldOverrideProps.concat(alsoAcceptProps)
+  )
+}
+
+export class PropertyHelper {
+  constructor(overrideProps = {}, inputStyles = {}){
+    this.overrideProps = overrideProps
+    this.inputStyles = inputStyles
+  }
+
+  overrideCollectProps = (
+    propName, 
+    alsoAcceptProps = []
+  ) => {
+    
+    let currentOverrideProps = this.overrideProps[propName]
+
+    // specific css should merge over inputStyles
+    if(!!currentOverrideProps.css === true){
+      currentOverrideProps = {
+        ...currentOverrideProps,
+        css: {
+          ...this.inputStyles,
+          ...currentOverrideProps.css,
+        }
+      }
+    }
+
+    return _.pick(  // only permit certain keys
+      currentOverrideProps, 
+      iframeOverrideProps.concat(alsoAcceptProps)
+    )
+  }
+
+  overrideFieldProps = (
+    propName, 
+    alsoAcceptProps = []
+  ) => {
+    return _.pick( // only permit certain keys
+      this.overrideProps[propName], 
+      fieldOverrideProps.concat(alsoAcceptProps)
+    )
+  }
+}

--- a/src/helpers/PropHelpers.test.js
+++ b/src/helpers/PropHelpers.test.js
@@ -1,0 +1,45 @@
+import { PropertyHelper } from "./PropHelpers"
+
+const overrideProps = {
+  "card-name": {
+    css: {
+      border: "1px solid"
+    },
+    placeholder: "New Placeholder",
+    color: "#ff8800",
+    errorColor: "darkred",
+    label: "New Label",
+  },
+  "card-number": {
+    placeholder: "New Placeholder",
+    showCardIcon: {
+      left: "5px",
+    },
+  }
+}
+
+describe("The PropertyHelper class ", () => {
+  it("Should return valid overrideProps", () => {
+
+    const propHelper = new PropertyHelper(overrideProps, {})
+
+    const iframeProps = propHelper.overrideCollectProps("card-name")
+    expect(iframeProps).to.have.all.keys("css", "placeholder", "color", "errorColor")
+
+    const fieldProps = propHelper.overrideFieldProps("card-name")
+    expect(fieldProps).to.have.keys("label")
+  })
+
+  it("Should allow additional props when specified", () => {
+    const propHelper = new PropertyHelper(overrideProps, {})
+    const iframeProps = propHelper.overrideCollectProps("card-number", ["showCardIcon"])
+    expect(iframeProps).to.have.all.keys("placeholder", "showCardIcon")
+  })
+
+  it("Should merge inputstyles with specific CSS", () => {
+    const propHelper = new PropertyHelper(overrideProps, { backgroundColor: "green" })
+    const iframeProps = propHelper.overrideCollectProps("card-name")
+    expect(iframeProps.css).to.have.all.keys("backgroundColor", "border")
+
+  })
+})

--- a/src/models/Instrument.js
+++ b/src/models/Instrument.js
@@ -8,9 +8,6 @@ import {
 
 import { logError, logWarning } from '../helpers/Logger'
 
-import _ from 'lodash'
-
-
 const INSTRUMENTS_LIST_RESOURCE = (account_id) => `/v1/accounts/${account_id}/instruments`
 const INSTRUMENTS_INSTANCE_RESOURCE = (account_id, instrument_id) => {
   return `/v1/accounts/${account_id}/instruments/${instrument_id}`
@@ -56,7 +53,7 @@ export class Instrument extends EntityModel {
     )
   }
 
-  static fetchInstrument = async (accountId, id, token, apiOptions = {} ) => {
+  static fetchInstrument = async function(accountId, id, token, apiOptions = {} ){
     let options = {
       method: 'GET',
       mode: 'cors',


### PR DESCRIPTION
Adding the ability to explicitly control the fields of the revops-js form elements
[Current Documentation](https://github.com/revops-io/revops.js/wiki/Using-Override-Props) 

__Current customizable fields:__ 
Iframe:  ` placeholder`, `color`, `errorColor`, `css`
Field: `label`
Special Fields: `showCardIcon`