### PR TITLE
customizable validation message

### DIFF
--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -122,7 +122,10 @@ export default class AchForm extends Component {
       errorColor: PropTypes.string,
       showCardLink: PropTypes.bool, // some fields only
       label: PropTypes.string,
-    })
+    }),
+
+    /** determines if validation errors should be shown */
+    showInlineError: PropTypes.bool
   }
 
   static defaultProps = {
@@ -434,6 +437,7 @@ export default class AchForm extends Component {
       sectionStyle,
       cardWidth = false,
       overrideProps = {},
+      showInlineError = true
     } = this.props
 
     const propHelper = new PropertyHelper(overrideProps)
@@ -464,7 +468,7 @@ export default class AchForm extends Component {
                 name="bankName"
                 label="Bank Name"
                 defaultValue={getDefaultValue(instrument, 'bankName', '')}
-                showInlineError={true}
+                showInlineError={showInlineError}
                 errors={errors}
                 {...propHelper.overrideFieldProps("bank-name")}
               />
@@ -474,7 +478,7 @@ export default class AchForm extends Component {
                 name="holderName"
                 label="Account Holder Name"
                 defaultValue={getDefaultValue(instrument, 'bankAccountHolderName', '')}
-                showInlineError={true}
+                showInlineError={showInlineError}
                 errors={errors}
                 {...propHelper.overrideFieldProps("bank-holder-name")}
               />
@@ -484,7 +488,7 @@ export default class AchForm extends Component {
                 name="postalCode"
                 label="Postal Code"
                 defaultValue={getDefaultValue(instrument, 'postalcode', '')}
-                showInlineError={true}
+                showInlineError={showInlineError}
                 errors={errors}
                 {...propHelper.overrideFieldProps("bank-postalcode")}
               />
@@ -494,7 +498,7 @@ export default class AchForm extends Component {
                 name="country"
                 label="Bank Country"
                 defaultValue={getDefaultValue(instrument, 'country', '')}
-                showInlineError={true}
+                showInlineError={showInlineError}
                 errors={errors}
                 {...propHelper.overrideFieldProps("bank-account-country")}
               />
@@ -504,7 +508,7 @@ export default class AchForm extends Component {
                 name="bankAccountHolderType"
                 label="Account Type"
                 defaultValue={getDefaultValue(instrument, 'accountHolderType', '')}
-                showInlineError={true}
+                showInlineError={showInlineError}
                 errors={errors}
                 {...propHelper.overrideFieldProps("bank-account-type")}
               />
@@ -514,7 +518,7 @@ export default class AchForm extends Component {
                 name="routingNumber"
                 label="Routing Number"
                 defaultValue={getDefaultValue(instrument, 'routingNumber', '')}
-                showInlineError={true}
+                showInlineError={showInlineError}
                 errors={errors}
                 {...propHelper.overrideFieldProps("bank-routing-number")}
               />
@@ -524,7 +528,7 @@ export default class AchForm extends Component {
                 name="accountNumber"
                 label="Account Number"
                 defaultValue={getDefaultValue(instrument, 'accountNumber', '')}
-                showInlineError={true}
+                showInlineError={showInlineError}
                 errors={errors}
                 {...propHelper.overrideFieldProps("bank-account-number")}
               />

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -117,7 +117,10 @@ export default class CreditCardForm extends Component {
       errorColor: PropTypes.string,
       showCardLink: PropTypes.bool, // some fields only
       label: PropTypes.string,
-    })
+    }),
+
+    /** determines if validation errors should be shown */
+    showInlineError: PropTypes.bool
 
   }
 
@@ -379,6 +382,7 @@ export default class CreditCardForm extends Component {
       sectionStyle,
       cardWidth = false,
       overrideProps = {},
+      showInlineError = true
     } = this.props
 
     const propHelper = new PropertyHelper(overrideProps)
@@ -409,7 +413,7 @@ export default class CreditCardForm extends Component {
                   name="holderName"
                   label="Card Holder"
                   defaultValue={getDefaultValue(instrument, 'cardName', '')}
-                  showInlineError={true}
+                  showInlineError={showInlineError}
                   errors={errors}
                   {...propHelper.overrideFieldProps("card-name")}
                 />
@@ -419,7 +423,7 @@ export default class CreditCardForm extends Component {
                   name="cardNumber"
                   label="Card Number"
                   defaultValue={getDefaultValue(instrument, 'cardNumber', '')}
-                  showInlineError={true}
+                  showInlineError={showInlineError}
                   errors={errors}
                   {...propHelper.overrideFieldProps("card-number", ["showCardIcon"])}
                 />
@@ -429,7 +433,7 @@ export default class CreditCardForm extends Component {
                   name="cardExpdate"
                   label="Expiration"
                   defaultValue={getDefaultValue(instrument, 'cardExpdate', '')}
-                  showInlineError={true}
+                  showInlineError={showInlineError}
                   errors={errors}
                   {...propHelper.overrideFieldProps("card-expdate")}
                 />
@@ -439,7 +443,7 @@ export default class CreditCardForm extends Component {
                   name="cardCvv"
                   label="CVC/CVV"
                   defaultValue={getDefaultValue(instrument, 'cardCvv', '')}
-                  showInlineError={true}
+                  showInlineError={showInlineError}
                   errors={errors}
                   {...propHelper.overrideFieldProps("card-cvc")}
                 />
@@ -449,7 +453,7 @@ export default class CreditCardForm extends Component {
                   name="postalCode"
                   label="Postal Code"
                   defaultValue={getDefaultValue(instrument, 'postalCode', '')}
-                  showInlineError={true}
+                  showInlineError={showInlineError}
                   errors={errors}
                   {...propHelper.overrideFieldProps("card-postalcode")}
                 />

--- a/src/ErrorMessage.js
+++ b/src/ErrorMessage.js
@@ -7,10 +7,16 @@ export const ErrorMessage = ({
   errors,
   errorKey,
   label,
+  errorMsg,
   component = 'span'
-}) => (
-  <span>{getErrorText(label, errorKey, errors)}</span>
-)
+}) => {
+  const error = getErrorText(label, errorKey, errors)
+  return (
+    <span className={`field-sub-text ${!!error === true ? "error" : ""}`} >
+      {!!error === true ? errorMsg || error : ""}
+    </span>
+  )
+}
 
 ErrorMessage.propTypes = {
   label: PropTypes.string,

--- a/src/ErrorMessage.js
+++ b/src/ErrorMessage.js
@@ -8,7 +8,6 @@ export const ErrorMessage = ({
   errorKey,
   label,
   errorMsg,
-  component = 'span'
 }) => {
   const error = getErrorText(label, errorKey, errors)
   return (
@@ -22,7 +21,7 @@ ErrorMessage.propTypes = {
   label: PropTypes.string,
   errorKey: PropTypes.string.isRequired,
   errors: PropTypes.any,
-  component: PropTypes.string,
+  errorMsg: PropTypes.string,
 }
 
 export default ErrorMessage

--- a/src/ErrorMessage.test.js
+++ b/src/ErrorMessage.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { ErrorMessage } from './ErrorMessage'
+
+
+describe('ErrorMessage', () => {
+  const generateMockProps = (props) => {
+    return {
+      id: "test123",
+      errorKey: "",
+      ...props
+    }
+  }
+
+  it('ErrorMessage should render without crashing', () => {
+    const mockProps = generateMockProps({})
+    const wrapper = shallow(<ErrorMessage  {...mockProps} />)
+
+    expect(wrapper.length).to.equal(1)
+    expect(wrapper.hasClass('field-sub-text')).to.equal(true)
+  })
+
+  it('Should show the default validation message', () => {
+    const mockProps = generateMockProps({
+      errors: {
+        name: {
+          errorMessages: ["World"]
+        }
+      },
+      label: "Hello",
+      errorKey: "name",
+    })
+    const wrapper = shallow(<ErrorMessage  {...mockProps} />)
+    expect(wrapper.length).to.equal(1)
+    expect(wrapper.hasClass('error')).to.equal(true)
+    expect(wrapper.text()).to.equal("Hello World")
+  })
+
+  it('Should show the custom errorMsg', () => {
+    const mockProps = generateMockProps({
+      errors: {
+        name: {
+          errorMessages: [""]
+        }
+      },
+      label: "",
+      errorKey: "name",
+      errorMsg: "Hello World"
+    })
+    const wrapper = shallow(<ErrorMessage  {...mockProps} />)
+    expect(wrapper.length).to.equal(1)
+    expect(wrapper.hasClass('error')).to.equal(true)
+    expect(wrapper.text()).to.equal("Hello World")
+  })
+
+})

--- a/src/Field.js
+++ b/src/Field.js
@@ -50,6 +50,7 @@ export class Field extends Component {
         <span className="field-space"></span>
         {this.props.showInlineError === true &&
           <ErrorMessage
+            errorMsg={this.props.errorMsg}
             label={this.props.label}
             errorKey={this.getElementKey()}
             errors={this.props.errors} />

--- a/src/SignUp.js
+++ b/src/SignUp.js
@@ -110,7 +110,10 @@ export class _SignUp extends Component {
           value: PropTypes.string,
           text: PropTypes.string
       }))
-    })
+    }),
+
+    /** determines if validation errors should be shown */
+    showInlineError: PropTypes.bool
   }
 
   componentDidMount() {
@@ -265,6 +268,7 @@ export class _SignUp extends Component {
       sectionStyle,
       cardWidth = false,
       overrideProps = {},
+      showInlineError = true
     } = this.props
 
     const propHelper = new PropertyHelper(overrideProps)
@@ -277,7 +281,7 @@ export class _SignUp extends Component {
             name="email"
             label="Email"
             defaultValue={getDefaultValue(account, 'email', '')}
-            showInlineError={true}
+            showInlineError={showInlineError}
             errors={errors}
             {...propHelper.overrideFieldProps("signup-email")}
           />

--- a/src/helpers/PropHelpers.js
+++ b/src/helpers/PropHelpers.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 const iframeOverrideProps = ['placeholder', 'color', 'errorColor', 'css', 'autoFocus']
-const fieldOverrideProps = ['label']
+const fieldOverrideProps = ['label', 'errorMsg', 'showInlineError']
 
 export class PropertyHelper {
   constructor(overrideProps = {}, inputStyles = {}){


### PR DESCRIPTION
# Summary 

Added support for customizing validation errors in revops-js by plumbing through the  `showInlineError` property to <Field /> and then <ErrorMessage /> . Also combined with existing `overrideProps` in order to provide fine-grain control when necessary. 

## Changes
- `showInlineError` can be set on <PaymentMehtod /> to disable all validation messages
- overrideProps now supports `showInlineError` and `errorMsg` allowing you to disable particular validation messages and replaces them with the `errorMsg` text
- added class names to the validation error text to make it easier to target in the DOM