### PR TITLE
remove network errors when `showNetworkError == false`

### DIFF
--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -6,6 +6,7 @@ import {
   convertAPIError,
   getDefaultValue,
   isInstrumentUpdate,
+  getErrorText,
 } from './FormHelpers'
 
 import { ButtonGroup } from './ButtonGroup'
@@ -149,6 +150,9 @@ export default class AchForm extends Component {
 
     /** Customized link that switches to the Plaid payment method */
     plaidLink: PropTypes.node,
+
+    /** optional prop to disable the network errors */
+    showNetworkError: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -175,7 +179,7 @@ export default class AchForm extends Component {
   }
 
   componentDidMount() {
-    const { apiOptions, loadingState} = this.props
+    const { apiOptions, loadingState } = this.props
     const conf = configure(apiOptions)
 
     configureVault(
@@ -184,7 +188,7 @@ export default class AchForm extends Component {
     )
 
     // setup debug information when using `loadingState`
-    if(!!loadingState === true && this.isThisMethod()){
+    if (!!loadingState === true && this.isThisMethod()) {
       this.loadingTimeOut = setTimeout(() => {
         logError("The form has not loaded after 5 seconds.", apiOptions.loggingLevel)
         this.onError({
@@ -195,7 +199,7 @@ export default class AchForm extends Component {
     }
   }
 
-  componentWillUnmount(){
+  componentWillUnmount() {
     clearTimeout(this.loadingTimeOut)
   }
 
@@ -463,7 +467,7 @@ export default class AchForm extends Component {
       creditCardLink = this.creditCardLink(),
     } = this.props
 
-    if(showCardLink === false){
+    if (showCardLink === false) {
       return null
     }
     return creditCardLink
@@ -475,7 +479,7 @@ export default class AchForm extends Component {
       plaidLink = this.plaidLink(),
     } = this.props
 
-    if(hideTogglePlaid === true){
+    if (hideTogglePlaid === true) {
       return null
     }
     return plaidLink
@@ -538,6 +542,7 @@ export default class AchForm extends Component {
       instrument,
       overrideProps = {},
       showInlineError = true,
+      showNetworkError = true,
       isUpdate,
       achLabel = <label className="ach-label">Paying by ACH</label>,
     } = this.props
@@ -639,6 +644,9 @@ export default class AchForm extends Component {
             }
           </div>
           <div className="ui clearing divider"></div>
+          {showNetworkError === true &&
+            <span className="network-error">{getErrorText('', 'networkError', errors)}</span>
+          }
           {this.getPlaidLink()}
           {!!this.props.saveRef === false &&
             <ButtonGroup

--- a/src/AchForm.test.js
+++ b/src/AchForm.test.js
@@ -33,6 +33,7 @@ describe('The AchForm Component', () => {
     expect(wrapper.find('section').length).to.equal(1)
     expect(wrapper.find('ButtonGroup').length).to.equal(1)
     expect(wrapper.find('.ach-label').length).to.equal(1)
+    expect(wrapper.find('.network-error').length).to.equal(1)
   })
 
   it('should not render button group when saveRef is defined', () => {
@@ -145,6 +146,12 @@ describe('The AchForm Component', () => {
     const wrapper = shallow(<AchForm  {...mockProps} />)
 
     expect(wrapper.find('.custom-label').length).to.equal(1)
+  })
+
+  it('should not show a network error', () => {
+    const mockProps = generateMockProps({ showNetworkError: false })
+    const wrapper = shallow(<AchForm  {...mockProps} />)
+    expect(wrapper.find('.network-error').length).to.equal(0)
   })
 
 })

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -142,6 +142,9 @@ export default class CreditCardForm extends Component {
     /** Customized link that switches to the ACH payment method */
     achLink: PropTypes.node,
 
+    /** optional prop to disable the network errors */
+    showNetworkError: PropTypes.bool,
+
   }
 
   static defaultProps = {
@@ -174,7 +177,7 @@ export default class CreditCardForm extends Component {
     )
 
     // setup debug information when using `loadingState`
-    if(!!loadingState === true && this.isThisMethod()){
+    if (!!loadingState === true && this.isThisMethod()) {
       this.loadingTimeOut = setTimeout(() => {
         logError("The form has not loaded after 5 seconds.", apiOptions.loggingLevel)
         this.onError({
@@ -185,7 +188,7 @@ export default class CreditCardForm extends Component {
     }
   }
 
-  componentWillUnmount(){
+  componentWillUnmount() {
     clearTimeout(this.loadingTimeOut)
   }
 
@@ -461,6 +464,7 @@ export default class CreditCardForm extends Component {
       instrument,
       overrideProps = {},
       showInlineError = true,
+      showNetworkError = true,
       isUpdate = false,
       creditCardLabel = <label className="cc-label">Paying by Credit Card</label>,
     } = this.props
@@ -544,7 +548,9 @@ export default class CreditCardForm extends Component {
             </div>
           </div>
           <div className="ui clearing divider"></div>
-          <span>{getErrorText('', 'networkError', errors)}</span>
+          {showNetworkError === true && 
+            <span className="network-error">{getErrorText('', 'networkError', errors)}</span>
+          }
           {!!this.props.saveRef === false &&
             <ButtonGroup
               showAccept={false}

--- a/src/CreditCardForm.test.js
+++ b/src/CreditCardForm.test.js
@@ -31,6 +31,7 @@ describe('The CreditCardForm Component', () => {
     expect(wrapper.find('#card-name').length).to.equal(1)
     expect(wrapper.find('#card-expdate').length).to.equal(1)
     expect(wrapper.find('#card-cvc').length).to.equal(1)
+    expect(wrapper.find('.network-error').length).to.equal(1)
   })
 
   it('should not render button group when saveRef is defined', () => {
@@ -129,4 +130,11 @@ describe('The CreditCardForm Component', () => {
 
     expect(wrapper.find('.custom-label').length).to.equal(1)
   })
+
+  it('should not show a network error', () => {
+    const mockProps = generateMockProps({ showNetworkError: false })
+    const wrapper = shallow(<CreditCardForm  {...mockProps} />)
+    expect(wrapper.find('.network-error').length).to.equal(0)
+  })
+
 })

--- a/src/PaymentMethod.js
+++ b/src/PaymentMethod.js
@@ -124,6 +124,9 @@ export default class PaymentMethod extends Component {
     /** user defined loading element */
     loadingState: PropTypes.node,
 
+    /** optional prop to disable the network errors */
+    showNetworkError: PropTypes.bool,
+
   }
 
   static defaultProps = {

--- a/src/PlaidForm.js
+++ b/src/PlaidForm.js
@@ -7,6 +7,7 @@ import {
   convertAPIError,
   getDefaultValue,
   isInstrumentUpdate,
+  getErrorText,
 } from './FormHelpers'
 
 import { ButtonGroup } from './ButtonGroup'
@@ -148,6 +149,9 @@ export default class PlaidForm extends Component {
 
     /** Customized link that switches to the credit card payment method */
     creditCardLink: PropTypes.node,
+
+    /** optional prop to disable the network errors */
+    showNetworkError: PropTypes.bool,
 
   }
 
@@ -478,6 +482,7 @@ export default class PlaidForm extends Component {
       instrument,
       overrideProps = {},
       showInlineError = true,
+      showNetworkError = true,
       isUpdate,
       plaidLabel = <label className="ach-label">Paying by ACH</label>,
     } = this.props
@@ -528,6 +533,9 @@ export default class PlaidForm extends Component {
           </div>
           {this.getACHLink()}
           <div className="ui clearing divider"></div>
+          {showNetworkError === true && 
+            <span className="network-error">{getErrorText('', 'networkError', errors)}</span>
+          }
           {!!this.props.saveRef === false &&
             <ButtonGroup
               loading={this.state.loading}

--- a/src/PlaidForm.test.js
+++ b/src/PlaidForm.test.js
@@ -28,6 +28,7 @@ describe('The PlaidForm Component', () => {
     expect(wrapper.find('section').length).to.equal(1)
     expect(wrapper.find('ButtonGroup').length).to.equal(1)
     expect(wrapper.find('TogglePlaid').length).to.equal(1)
+    expect(wrapper.find('.network-error').length).to.equal(1)
 
   })
 
@@ -163,4 +164,11 @@ describe('The PlaidForm Component', () => {
 
     expect(wrapper.find('.custom-label').length).to.equal(1)
   })
+
+  it('should not show a network error', () => {
+    const mockProps = generateMockProps({ showNetworkError: false })
+    const wrapper = shallow(<PlaidForm  {...mockProps} />)
+    expect(wrapper.find('.network-error').length).to.equal(0)
+  })
+
 })

--- a/src/SignUp.js
+++ b/src/SignUp.js
@@ -109,11 +109,14 @@ export class _SignUp extends Component {
         PropTypes.shape({
           value: PropTypes.string,
           text: PropTypes.string
-      }))
+        }))
     }),
 
     /** determines if validation errors should be shown */
-    showInlineError: PropTypes.bool
+    showInlineError: PropTypes.bool,
+
+    /** optional prop to disable the network errors */
+    showNetworkError: PropTypes.bool,
   }
 
   componentDidMount() {
@@ -151,8 +154,8 @@ export class _SignUp extends Component {
   }
 
   initialize = () => {
-    const { 
-      account,  
+    const {
+      account,
       inputStyles,
       overrideProps = {},
     } = this.props
@@ -268,7 +271,8 @@ export class _SignUp extends Component {
       sectionStyle,
       cardWidth = false,
       overrideProps = {},
-      showInlineError = true
+      showInlineError = true,
+      showNetworkError = true,
     } = this.props
 
     const propHelper = new PropertyHelper(overrideProps)
@@ -287,7 +291,9 @@ export class _SignUp extends Component {
           />
         </div>
         <div className="ui clearing divider"></div>
-        <span>{getErrorText('', 'networkError', errors)}</span>
+        {showNetworkError === true &&
+          <span className="network-error">{getErrorText('', 'networkError', errors)}</span>
+        }
         {!!this.props.saveRef === false &&
           <ButtonGroup
             showAccept={false}

--- a/src/SignUp.test.js
+++ b/src/SignUp.test.js
@@ -26,6 +26,7 @@ describe('The SignUp Component', () => {
     expect(wrapper.find('#signup-form').length).to.equal(1)
     expect(wrapper.find('#signup-email').length).to.equal(1)
     expect(wrapper.find('ButtonGroup').length).to.equal(1)
+    expect(wrapper.find('.network-error').length).to.equal(1)
   })
 
   it('should not render button group when saveRef is defined', () => {
@@ -70,5 +71,11 @@ describe('The SignUp Component', () => {
     expect(wrapper.instance().state.status).to.equal(false)
     expect(wrapper.instance().state.response).to.equal(false)
     expect(mockProps.account.saveWithSecureForm.call.length).to.equal(1)
+  })
+
+  it('should not show a network error', () => {
+    const mockProps = generateMockProps({ showNetworkError: false })
+    const wrapper = shallow(<_SignUp  {...mockProps} />)
+    expect(wrapper.find('.network-error').length).to.equal(0)
   })
 })


### PR DESCRIPTION
Added the `showNetworkError` property to prevent the default error message from appearing.  