### PR TITLE
Clean up timeout when we remove the loader

### DIFF
--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -206,6 +206,7 @@ export default class AchForm extends Component {
   componentDidUpdate(prevProps) {
     const { method } = this.props
     if (prevProps.method !== method && this.isThisMethod()) {
+      clearTimeout(this.loadingTimeOut)
       this.setState({ loading: false })
     }
   }

--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -205,8 +205,11 @@ export default class AchForm extends Component {
 
   componentDidUpdate(prevProps) {
     const { method } = this.props
-    if (prevProps.method !== method && this.isThisMethod()) {
-      clearTimeout(this.loadingTimeOut)
+    if (prevProps.method !== method) {
+      // clean up the timeout if the previous method was this method and is no longer
+      if((prevProps.method === PaymentMethods.METHOD_ACH)){
+        clearTimeout(this.loadingTimeOut)
+      }
       this.setState({ loading: false })
     }
   }

--- a/src/AchForm.test.js
+++ b/src/AchForm.test.js
@@ -2,7 +2,13 @@ import React from 'react';
 
 import AchForm from './AchForm'
 
+jest.useFakeTimers();
+
 describe('The AchForm Component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  });
+
   const generateMockProps = (props) => {
     return {
       id: "test123",
@@ -152,6 +158,31 @@ describe('The AchForm Component', () => {
     const mockProps = generateMockProps({ showNetworkError: false })
     const wrapper = shallow(<AchForm  {...mockProps} />)
     expect(wrapper.find('.network-error').length).to.equal(0)
+  })
+  
+  it('should remove the loading state when method changes', () => {
+    const mockProps = generateMockProps({ method: "ach", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<AchForm  {...mockProps} />)
+
+    expect(wrapper.state().loading).to.equal(true)
+    wrapper.setProps({method: "plaid"})
+    expect(wrapper.state().loading).to.equal(false)
+  })
+
+  it('should set a timeout and remove it when method changes', () => {
+    const mockProps = generateMockProps({ method: "ach", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<AchForm  {...mockProps} />)
+
+    expect(setTimeout.mock.calls.length).to.equal(1);
+    wrapper.setProps({method: "plaid"})
+    expect(clearTimeout.mock.calls.length).to.equal(1);
+  })
+
+  it('should not set a timeout', () => {
+    const mockProps = generateMockProps({ method: "plaid", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<AchForm  {...mockProps} />)
+
+    expect(setTimeout.mock.calls.length).to.equal(0);
   })
 
 })

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -200,8 +200,11 @@ export default class CreditCardForm extends Component {
 
   componentDidUpdate(prevProps) {
     const { method } = this.props
-    if (prevProps.method !== method && this.isThisMethod()) {
-      clearTimeout(this.loadingTimeOut)
+    if (prevProps.method !== method) {
+      // clean up the timeout if the previous method was this method and is no longer
+      if((prevProps.method === PaymentMethods.METHOD_CARD || prevProps.method === 'card')){
+        clearTimeout(this.loadingTimeOut)
+      }
       this.setState({ loading: false })
     }
   }

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -201,6 +201,7 @@ export default class CreditCardForm extends Component {
   componentDidUpdate(prevProps) {
     const { method } = this.props
     if (prevProps.method !== method && this.isThisMethod()) {
+      clearTimeout(this.loadingTimeOut)
       this.setState({ loading: false })
     }
   }

--- a/src/CreditCardForm.test.js
+++ b/src/CreditCardForm.test.js
@@ -2,8 +2,13 @@ import React from 'react';
 
 import CreditCardForm from './CreditCardForm'
 
+jest.useFakeTimers();
 
 describe('The CreditCardForm Component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  });
+
   const generateMockProps = (props) => {
     return {
       id: "test123",
@@ -135,6 +140,31 @@ describe('The CreditCardForm Component', () => {
     const mockProps = generateMockProps({ showNetworkError: false })
     const wrapper = shallow(<CreditCardForm  {...mockProps} />)
     expect(wrapper.find('.network-error').length).to.equal(0)
+  })
+
+  it('should remove the loading state when method changes', () => {
+    const mockProps = generateMockProps({ method: "credit-card", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<CreditCardForm  {...mockProps} />)
+
+    expect(wrapper.state().loading).to.equal(true)
+    wrapper.setProps({method: "ach"})
+    expect(wrapper.state().loading).to.equal(false)
+  })
+
+  it('should set a timeout and remove it when method changes', () => {
+    const mockProps = generateMockProps({ method: "credit-card", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<CreditCardForm  {...mockProps} />)
+
+    expect(setTimeout.mock.calls.length).to.equal(1);
+    wrapper.setProps({method: "ach"})
+    expect(clearTimeout.mock.calls.length).to.equal(1);
+  })
+
+  it('should not set a timeout', () => {
+    const mockProps = generateMockProps({ method: "plaid", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<CreditCardForm  {...mockProps} />)
+
+    expect(setTimeout.mock.calls.length).to.equal(0);
   })
 
 })

--- a/src/PlaidForm.js
+++ b/src/PlaidForm.js
@@ -220,6 +220,7 @@ export default class PlaidForm extends Component {
   componentDidUpdate(prevProps) {
     const { method } = this.props
     if (prevProps.method !== method && this.isThisMethod()) {
+      clearTimeout(this.loadingTimeOut)
       this.setState({ loading: false })
     }
   }

--- a/src/PlaidForm.js
+++ b/src/PlaidForm.js
@@ -219,8 +219,11 @@ export default class PlaidForm extends Component {
 
   componentDidUpdate(prevProps) {
     const { method } = this.props
-    if (prevProps.method !== method && this.isThisMethod()) {
-      clearTimeout(this.loadingTimeOut)
+    if (prevProps.method !== method) {
+      // clean up the timeout if the previous method was this method and is no longer
+      if(prevProps.method === PaymentMethods.METHOD_PLAID){
+        clearTimeout(this.loadingTimeOut)
+      }
       this.setState({ loading: false })
     }
   }

--- a/src/PlaidForm.test.js
+++ b/src/PlaidForm.test.js
@@ -2,7 +2,13 @@ import React from 'react';
 
 import PlaidForm from './PlaidForm'
 
+jest.useFakeTimers();
+
 describe('The PlaidForm Component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  });
+
   const generateMockProps = (props) => {
     return {
       id: "test123",
@@ -169,6 +175,31 @@ describe('The PlaidForm Component', () => {
     const mockProps = generateMockProps({ showNetworkError: false })
     const wrapper = shallow(<PlaidForm  {...mockProps} />)
     expect(wrapper.find('.network-error').length).to.equal(0)
+  })
+
+  it('should remove the loading state when method changes', () => {
+    const mockProps = generateMockProps({ method: "plaid", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<PlaidForm  {...mockProps} />)
+
+    expect(wrapper.state().loading).to.equal(true)
+    wrapper.setProps({method: "ach"})
+    expect(wrapper.state().loading).to.equal(false)
+  })
+
+  it('should set a timeout and remove it when method changes', () => {
+    const mockProps = generateMockProps({ method: "plaid", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<PlaidForm  {...mockProps} />)
+
+    expect(setTimeout.mock.calls.length).to.equal(1);
+    wrapper.setProps({method: "ach"})
+    expect(clearTimeout.mock.calls.length).to.equal(1);
+  })
+
+  it('should not set a timeout', () => {
+    const mockProps = generateMockProps({ method: "ach", loadingState: <h1>Test</h1> })
+    const wrapper = shallow(<PlaidForm  {...mockProps} />)
+
+    expect(setTimeout.mock.calls.length).to.equal(0);
   })
 
 })


### PR DESCRIPTION
Addresses Issue #56 

Revops-js is designed to drop the loader when an explicit change is detected to the `method` prop. This was removing the loader as expected but was not removing the timeout being set to detect long loads. 

To fix, we add a similar code path as we have in `componentDidUnmount` to remove the timeout whenever we are removing the `loadingState`

