### PR TITLE
Update Babel build system to remove need for unsafe-eval in CSP 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,18 @@
 {
+  "env": {
+    "test": {
+      "presets": [["@babel/preset-env"], "@babel/preset-react"]
+    }
+  },
   "presets": [
-    ["env", {
-      "modules": false
-    }],
-    "stage-0",
-    "react"
-  ]
+    [
+      "@babel/preset-env",
+      {
+        "modules": false
+      }
+    ],
+    "@babel/preset-react"
+  ],
+  "plugins": ["@babel/plugin-proposal-class-properties"],
+  "ignore": ["node_modules/**"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 9
-  - 8
+  - 11
+  - 10

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
   "engines": {
-    "node": ">=8",
-    "npm": ">=5"
+    "node": ">=10"
   },
   "scripts": {
     "test": "cross-env CI=1 react-scripts test --env=jsdom",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,10 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.8.4",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@svgr/rollup": "^2.4.1",
     "axios-mock-adapter": "^1.17.0",
-    "babel-core": "^6.26.3",
-    "babel-plugin-external-helpers": "^6.22.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
     "chai": "^4.2.0",
     "cross-env": "^5.2.1",
     "enzyme": "^3.10.0",
@@ -49,11 +46,11 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-standard": "^3.1.0",
     "gh-pages": "^1.2.0",
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
     "react-scripts": "^3.0.1",
     "rollup": "^0.64.1",
-    "rollup-plugin-babel": "^3.0.7",
+    "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
@@ -68,6 +65,8 @@
     "themes"
   ],
   "dependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/runtime": "^7.8.4",
     "babel-plugin-transform-runtime": "^6.23.0",
     "lodash": "^4.17.15",
     "react-plaid-link": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revops-js",
-  "version": "1.0.0-beta22",
+  "version": "1.0.0-beta23",
   "description": "Official RevOps Javascript Component Library",
   "author": "RevOps",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,24 +1,24 @@
-import babel from 'rollup-plugin-babel'
-import commonjs from 'rollup-plugin-commonjs'
-import external from 'rollup-plugin-peer-deps-external'
-import postcss from 'rollup-plugin-postcss'
-import resolve from 'rollup-plugin-node-resolve'
-import url from 'rollup-plugin-url'
-import svgr from '@svgr/rollup'
+import babel from "rollup-plugin-babel";
+import commonjs from "rollup-plugin-commonjs";
+import external from "rollup-plugin-peer-deps-external";
+import postcss from "rollup-plugin-postcss";
+import resolve from "rollup-plugin-node-resolve";
+import url from "rollup-plugin-url";
+import svgr from "@svgr/rollup";
 
-import pkg from './package.json'
+import pkg from "./package.json";
 
 export default {
-  input: 'src/index.js',
+  input: "src/index.js",
   output: [
     {
       file: pkg.main,
-      format: 'cjs',
+      format: "cjs",
       sourcemap: true
     },
     {
       file: pkg.module,
-      format: 'es',
+      format: "es",
       sourcemap: true
     }
   ],
@@ -27,18 +27,18 @@ export default {
     postcss({
       modules: true,
       extract: true,
-      extensions: ['.css']
+      extensions: [".css"]
     }),
     url(),
     svgr(),
     babel({
       runtimeHelpers: true,
-      exclude: 'node_modules/**',
-      plugins: ['external-helpers', 'transform-runtime']
+      exclude: "node_modules/**",
+      plugins: ["@babel/plugin-transform-runtime"]
     }),
     resolve({
       browser: true
     }),
     commonjs()
   ]
-}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export const configureVault = (
   apiOptions = {
     env: 'production',
   },
-  onLoad: false,
+  onLoad
 ) => {
   if (!!window !== true && !!document !== true) {
     throw new Error("Illegal call. `configureVault` is being executed outside browser context.")

--- a/src/models/EntityModel.js
+++ b/src/models/EntityModel.js
@@ -5,9 +5,6 @@ import { EntityDate } from './index'
 
 export class EntityModel {
 
-  dateUpdated: string
-  dateCreated: string
-
   constructor(params = {}) {
     this.id = params.id || this._generateUUID()
     this.dateUpdated = params.dateUpdated || new EntityDate().toIsoString()


### PR DESCRIPTION
Previous a bit of code inserted by Babel was causing the script to be loaded using a `Function` constructor which required a `unsafe-eval` in CSP headers. 

Updating the Babel build system seems to have resolved this issue. This also required a few minor tweaks to `index.js` and `EntityModel`

Related, https://github.com/facebook/regenerator/issues/336