### PR TITLE
Remove postal code

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/runtime": "^7.8.4",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "react-plaid-link": "^1.5.0"
   },
   "standard": {

--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -122,12 +122,15 @@ export default class AchForm extends Component {
      * Only allowed properties are allowed, see documentation for details. 
      */
     overrideProps: PropTypes.shape({
-      css: PropTypes.object, // CSS in JS
-      placeholder: PropTypes.string,
-      color: PropTypes.string,
-      errorColor: PropTypes.string,
-      showCardLink: PropTypes.bool, // some fields only
-      label: PropTypes.string,
+      "bank-postalcode" : PropTypes.shape({
+        css: PropTypes.object, // CSS in JS
+        placeholder: PropTypes.string,
+        color: PropTypes.string,
+        errorColor: PropTypes.string,
+        showCardLink: PropTypes.bool, // some fields only
+        label: PropTypes.string,
+        hide: PropTypes.bool
+      })
     }),
 
     /** determines if validation errors should be shown */
@@ -560,6 +563,7 @@ export default class AchForm extends Component {
     } = this.props
 
     const propHelper = new PropertyHelper(overrideProps)
+    const hidePostalCode = overrideProps["bank-postalcode"] && overrideProps["bank-postalcode"].hide
 
     return (
       <React.Fragment>
@@ -603,15 +607,22 @@ export default class AchForm extends Component {
                   {...propHelper.overrideFieldProps("bank-holder-name")}
                 />
 
-                <Field
-                  id="bank-postalcode"
-                  name="postalCode"
-                  label="Postal Code"
-                  defaultValue={getDefaultValue(instrument, 'postalcode', '')}
-                  showInlineError={showInlineError}
-                  errors={errors}
-                  {...propHelper.overrideFieldProps("bank-postalcode")}
-                />
+                {!hidePostalCode && (
+                    <Field
+                      id="bank-postalcode"
+                      name="postalCode"
+                      label="Postal Code"
+                      defaultValue={getDefaultValue(
+                        instrument,
+                        "postalcode",
+                        ""
+                      )}
+                      showInlineError={showInlineError}
+                      errors={errors}
+                      {...propHelper.overrideFieldProps("bank-postalcode")}
+                    />
+                  )
+                }
 
                 <Field
                   id="bank-account-country"

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -116,12 +116,15 @@ export default class CreditCardForm extends Component {
      * Only allowed properties are allowed, see see documentation for details.
      */
     overrideProps: PropTypes.shape({
-      css: PropTypes.object, // CSS in JS
-      placeholder: PropTypes.string,
-      color: PropTypes.string,
-      errorColor: PropTypes.string,
-      showCardLink: PropTypes.bool, // some fields only
-      label: PropTypes.string,
+      "card-postalcode" : PropTypes.shape({
+        css: PropTypes.object, // CSS in JS
+        placeholder: PropTypes.string,
+        color: PropTypes.string,
+        errorColor: PropTypes.string,
+        showCardLink: PropTypes.bool, // some fields only
+        label: PropTypes.string,
+        hide: PropTypes.bool
+      })
     }),
 
     /** determines if validation errors should be shown */
@@ -482,6 +485,7 @@ export default class CreditCardForm extends Component {
     } = this.props
 
     const propHelper = new PropertyHelper(overrideProps)
+    const hidePostalCode = overrideProps["card-postalcode"] && overrideProps["card-postalcode"].hide
 
     return (
       <React.Fragment>
@@ -546,15 +550,21 @@ export default class CreditCardForm extends Component {
                     {...propHelper.overrideFieldProps("card-cvc")}
                   />
 
-                  <Field
-                    id="card-postalcode"
-                    name="postalCode"
-                    label="Postal Code"
-                    defaultValue={getDefaultValue(instrument, 'postalCode', '')}
-                    showInlineError={showInlineError}
-                    errors={errors}
-                    {...propHelper.overrideFieldProps("card-postalcode")}
-                  />
+                  {!hidePostalCode && (
+                      <Field
+                        id="card-postalcode"
+                        name="postalCode"
+                        label="Postal Code"
+                        defaultValue={getDefaultValue(
+                          instrument,
+                          "postalCode",
+                          ""
+                        )}
+                        showInlineError={showInlineError}
+                        errors={errors}
+                        {...propHelper.overrideFieldProps("card-postalcode")}
+                      />
+                    )}
                 </React.Fragment>
               }
             </div>


### PR DESCRIPTION
Revops.js did not provide any way to remove the postal code section from PaymentMethod component.

**In this MR:**
- allow postal code to be removed from both CC and ACH form