### PR TITLE
Bugfix/update count based on removed fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revops-js",
-  "version": "1.0.0-beta26",
+  "version": "1.0.0-beta27",
   "description": "Official RevOps Javascript Component Library",
   "author": "RevOps",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revops-js",
-  "version": "1.0.0-beta27",
+  "version": "1.0.0-beta28",
   "description": "Official RevOps Javascript Component Library",
   "author": "RevOps",
   "license": "MIT",

--- a/src/AchForm.js
+++ b/src/AchForm.js
@@ -514,10 +514,9 @@ export default class AchForm extends Component {
   }
 
   finishedLoading = (formState) => {
-    const { onLoad } = this.props
-
-    if (this.state.loading === true && this.isThisMethod()) {
-      if (Object.keys(formState).length === NUMBER_OF_FIELDS) {
+    const { onLoad, overrideProps } = this.props
+    if (!!this.state.loading && this.isThisMethod()) {
+      if (Object.keys(formState).length === getExpectedFieldCount(overrideProps)) {
         this.setState({ loading: false })
 
         clearTimeout(this.loadingTimeOut)
@@ -686,3 +685,9 @@ export default class AchForm extends Component {
     )
   }
 }
+
+const getExpectedFieldCount = ( overrideProps = {}) => {
+  const hidePostalCode =
+    !!(overrideProps["bank-postalcode"] && overrideProps["bank-postalcode"].hide)
+  return hidePostalCode ? NUMBER_OF_FIELDS - 1 : NUMBER_OF_FIELDS;
+};

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -376,10 +376,9 @@ export default class CreditCardForm extends Component {
   }
 
   isFinishedLoading = (formState) => {
-    const { onLoad } = this.props
-
-    if (this.state.loading === true && this.isThisMethod()) {
-      if (Object.keys(formState).length === NUMBER_OF_FIELDS) {
+    const { onLoad, overrideProps } = this.props
+    if (!!this.state.loading && this.isThisMethod()) {
+      if (Object.keys(formState).length === getExpectedFieldCount(overrideProps)) {
         this.setState({ loading: false })
 
         clearTimeout(this.loadingTimeOut)
@@ -590,3 +589,9 @@ export default class CreditCardForm extends Component {
     )
   }
 }
+
+const getExpectedFieldCount = (overrideProps = {}) => {
+  const hidePostalCode =
+    !!(overrideProps["card-postalcode"] && overrideProps["card-postalcode"].hide)
+  return hidePostalCode ? NUMBER_OF_FIELDS - 1 : NUMBER_OF_FIELDS;
+};


### PR DESCRIPTION
Even when the postal-code field was removed, we would still expect the form to load before we would record the form as fully loaded. 

This PR: 
- changes the number of expected fields when the postal code is removed. 