### PR TITLE
add custom postal code validation prop

### DIFF
--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -296,7 +296,7 @@ export default class CreditCardForm extends Component {
 
     this.initForm('card-postalcode', () =>
       form.field("#card-postalcode .field-space", {
-        type: postalCodeValidations ? "text" : "zip-code",
+        type: "text",
         errorColor: this.props.errorColor,
         defaultValue: getDefaultValue(instrument, 'postalCode', ''),
         name: prefix + 'postal_code',

--- a/src/CreditCardForm.js
+++ b/src/CreditCardForm.js
@@ -148,6 +148,9 @@ export default class CreditCardForm extends Component {
     /** optional prop to disable the network errors */
     showNetworkError: PropTypes.bool,
 
+    /** optional prop to provide custom postal code validations */
+    postalCodeValidations: PropTypes.arrayOf(PropTypes.string),
+
   }
 
   static defaultProps = {
@@ -218,6 +221,7 @@ export default class CreditCardForm extends Component {
       createAccount = false,
       inputStyles,
       overrideProps = {},
+      postalCodeValidations = null,
     } = this.props
     let conf = configure(this.props.apiOptions)
 
@@ -292,12 +296,12 @@ export default class CreditCardForm extends Component {
 
     this.initForm('card-postalcode', () =>
       form.field("#card-postalcode .field-space", {
-        type: "zip-code",
+        type: postalCodeValidations ? "text" : "zip-code",
         errorColor: this.props.errorColor,
         defaultValue: getDefaultValue(instrument, 'postalCode', ''),
         name: prefix + 'postal_code',
         placeholder: "Postal code",
-        validations: ["required"],
+        validations: postalCodeValidations ? postalCodeValidations : ["required"],
         css: this.props.inputStyles,
         ...propHelper.overrideCollectProps('card-postalcode'),
       })


### PR DESCRIPTION
add custom postal code validation prop  `postalCodeValidations` that overrides the default values

![image](https://user-images.githubusercontent.com/52764816/153522707-f74306d6-a371-401f-9f70-731721f14e17.png)
