### PR TITLE
update uuidv4 import

### DIFF
--- a/src/models/EntityModel.js
+++ b/src/models/EntityModel.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 import { EntityDate } from './index'
 


### PR DESCRIPTION
Latest version of uuid no longer exports uuidv4 directly.  Change to recommended ES6 import:

https://github.com/uuidjs/uuid#quickstart